### PR TITLE
feat: add birth_date field to user types

### DIFF
--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -50,6 +50,7 @@ export type Database = {
       users: {
         Row: {
           avatar_url: string
+          birth_date: string | null
           description: string
           email: string
           id: string
@@ -57,6 +58,7 @@ export type Database = {
         }
         Insert: {
           avatar_url: string
+          birth_date?: string | null
           description: string
           email: string
           id: string
@@ -64,6 +66,7 @@ export type Database = {
         }
         Update: {
           avatar_url?: string
+          birth_date?: string | null
           description?: string
           email?: string
           id?: string


### PR DESCRIPTION
This pull request includes an update to the `Database` type in `src/database.types.ts` to add a new optional field for users' birth dates. 

* [`src/database.types.ts`](diffhunk://#diff-0ae92d0c57beef3c66d046b1f9f7e0096489d2a28779759ff97c7748ef106fd6R53-R69): Added `birth_date` as an optional field to the `users` table in the `Row`, `Insert`, and `Update` types.